### PR TITLE
Document inference performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Use an input video that:
 - has at least 121 frames;
 - contains only mild camera motion.
 
+### Inference Efficiency
+
+See [Inference performance](docs/inference_performance.md) for measured 6-view runtimes and peak GPU memory usage on H20-3E, H200, and RTX A6000 GPUs.
+
 ## 3DGS Reconstruction
 
 See the [nerfstudio guide](docs/nerfstudio.md) for details.

--- a/docs/inference_performance.md
+++ b/docs/inference_performance.md
@@ -1,0 +1,30 @@
+# Inference performance
+
+This page reports inference efficiency for the [6-view full-orbit](../README.md#6-view-full-orbit) example using:
+
+```bash
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+python inference.py \
+    --video_path "data/source/pexels/2785536-uhd_2160_3840_25fps.mp4" \
+    --views_per_layer 6
+```
+
+Each configuration reports the median of three runs.
+
+| GPU | Backend | GVHMR (min) | Skeleton extraction (min) | Denoising (min) | Peak CUDA allocated (GiB) |
+| --- | --- | ---: | ---: | ---: | ---: |
+| H200 | SDPA | 0.94 | 0.57 | 9.17 | 43.34 |
+| H200 | FlashAttention-3 | 0.94 | 0.57 | 7.84 | 43.34 |
+| H20-3E | SDPA | 0.97 | 0.55 | 20.59 | 43.34 |
+| H20-3E | FlashAttention-3 | 0.97 | 0.55 | 16.62 | 43.34 |
+| RTX A6000 | SDPA | 1.70 | 1.06 | 22.93 | 43.32 |
+
+Metrics are defined as follows:
+
+- `GVHMR`: tracking, ViTPose, image-feature extraction, and motion prediction.
+- `Skeleton extraction`: target-view skeleton-condition rendering.
+- `Denoising`: the generation stage affected by the attention backend.
+- `Peak CUDA allocated`: the maximum live tensor allocation during generation.
+
+> [!NOTE]
+> On supported GPUs, FlashAttention-3 is selected automatically once installed.


### PR DESCRIPTION
Source snapshot: krahets/4DAnyone@08bf63e89bcd8ddca5cb17ae86e53d423c366808

- Add measured 6-view runtimes for H200, H20-3E, and RTX A6000 GPUs.
- Report median GVHMR and denoising timings, plus peak CUDA allocation.
- Compare SDPA and FlashAttention-3 where supported.
- Link the measurements from a dedicated README section.

Validation:
- The isolated public snapshot matches the private source commit.
- Privacy, submodule, formatting, and release-tree checks passed.