### PR TITLE
Use cyclic TCR for partial yaw layouts

### DIFF
--- a/fdanyone/model/inference.py
+++ b/fdanyone/model/inference.py
@@ -322,7 +322,6 @@ def _denoise_targets(
         group_size=view_plan.views_per_group,
         num_steps=INFERENCE.num_inference_steps,
         enable_tcr=view_plan.tcr_active,
-        circular=view_plan.closed_yaw,
     )
 
     with torch.inference_mode(), _bf16_autocast():

--- a/fdanyone/model/inference.py
+++ b/fdanyone/model/inference.py
@@ -321,7 +321,7 @@ def _denoise_targets(
         num_layers=view_plan.num_layers,
         group_size=view_plan.views_per_group,
         num_steps=INFERENCE.num_inference_steps,
-        enable_tcr=view_plan.tcr_active,
+        enable_tcr=view_plan.enable_tcr,
     )
 
     with torch.inference_mode(), _bf16_autocast():

--- a/fdanyone/model/routing.py
+++ b/fdanyone/model/routing.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from itertools import pairwise
-
 
 def _validate_grouping(num_views: int, group_size: int) -> int:
     if num_views <= 0 or group_size <= 0 or num_views % group_size:
@@ -15,27 +13,14 @@ def view_groups(
     num_views: int,
     group_size: int,
     offset: int = 0,
-    *,
-    circular: bool = True,
 ) -> tuple[tuple[int, ...], ...]:
-    """Partition one camera layer, optionally without joining its endpoints."""
+    """Partition one camera layer into cyclically shifted groups."""
 
     num_groups = _validate_grouping(num_views, group_size)
-    if circular:
-        return tuple(
-            tuple((group_index * group_size + offset + local_index) % num_views for local_index in range(group_size))
-            for group_index in range(num_groups)
-        )
-
-    # Shifting an open sequence creates smaller boundary groups instead of a
-    # false neighborhood between the two ends of a partial yaw span.
-    offset %= group_size
-    boundaries = [0]
-    if offset:
-        boundaries.append(offset)
-    boundaries.extend(range(offset + group_size, num_views, group_size))
-    boundaries.append(num_views)
-    return tuple(tuple(range(start, end)) for start, end in pairwise(boundaries))
+    return tuple(
+        tuple((group_index * group_size + offset + local_index) % num_views for local_index in range(group_size))
+        for group_index in range(num_groups)
+    )
 
 
 def routing_steps(
@@ -45,7 +30,6 @@ def routing_steps(
     group_size: int,
     num_steps: int,
     enable_tcr: bool,
-    circular: bool,
 ) -> tuple[tuple[tuple[int, ...], ...], ...]:
     """Return layer-local target groups for every denoising step."""
 
@@ -62,7 +46,6 @@ def routing_steps(
                 views_per_layer,
                 group_size,
                 step_index if enable_tcr else 0,
-                circular=circular,
             )
         )
         for step_index in range(num_steps)

--- a/fdanyone/output.py
+++ b/fdanyone/output.py
@@ -181,8 +181,6 @@ def export_result(
                 "num_layers": view_plan.num_layers,
                 "num_target_views": view_plan.num_target_views,
                 "groups_per_layer": view_plan.groups_per_layer,
-                "tcr_active": view_plan.tcr_active,
-                "routing_topology": "circular",
             },
             "attention_backend": attention_backend,
             "inference_steps": INFERENCE.num_inference_steps,

--- a/fdanyone/output.py
+++ b/fdanyone/output.py
@@ -182,7 +182,7 @@ def export_result(
                 "num_target_views": view_plan.num_target_views,
                 "groups_per_layer": view_plan.groups_per_layer,
                 "tcr_active": view_plan.tcr_active,
-                "routing_topology": "circular" if view_plan.closed_yaw else "open",
+                "routing_topology": "circular",
             },
             "attention_backend": attention_backend,
             "inference_steps": INFERENCE.num_inference_steps,

--- a/fdanyone/views.py
+++ b/fdanyone/views.py
@@ -56,10 +56,6 @@ class ViewPlan:
         return self.groups_per_layer * self.num_layers
 
     @property
-    def tcr_active(self) -> bool:
-        return self.enable_tcr
-
-    @property
     def target_views(self) -> tuple[TargetView, ...]:
         step = self.yaw_span / self.views_per_layer
         return tuple(

--- a/fdanyone/views.py
+++ b/fdanyone/views.py
@@ -56,10 +56,6 @@ class ViewPlan:
         return self.groups_per_layer * self.num_layers
 
     @property
-    def closed_yaw(self) -> bool:
-        return self.yaw_span == 360
-
-    @property
     def tcr_active(self) -> bool:
         return self.enable_tcr
 

--- a/inference.py
+++ b/inference.py
@@ -45,8 +45,7 @@ def inference(
             divide views_per_layer.
         enable_rcp: Use proposal views before generating more than six targets.
             The proposal count follows views_per_group.
-        enable_tcr: Shift view groups between denoising steps. Partial yaw
-            ranges remain open sequences rather than wrapping their endpoints.
+        enable_tcr: Shift view groups cyclically between denoising steps.
         data_dir: Root for reusable GVHMR motion and final 4DAnyone outputs.
         model_dir: Model root; missing public checkpoints download here.
         checkpoint_path: Local 4DAnyone checkpoint override.


### PR DESCRIPTION
## Summary

- use the same cyclic TCR grouping for full rings and partial yaw layouts
- keep group count and group size constant across denoising steps
- remove the obsolete open-routing branch, constant routing metadata, and redundant `tcr_active` alias

## Validation

- private source: 223 CPU tests passed, 1 optional PyTorch test skipped
- Ruff check and format check passed
- public snapshot CLI and clean-TCR routing smoke passed
- public diff contains only the five expected reader-facing files