### PR TITLE
Expand inference performance benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ conda activate 4danyone
 pip install -r requirements.txt
 ```
 
-For faster inference, optionally install [FlashAttention-3](https://github.com/Dao-AILab/flash-attention/tree/main/hopper) or [SageAttention](https://github.com/thu-ml/SageAttention).
-
 Missing models and examples are downloaded automatically on first use. You can also download them manually:
 
 ```bash
@@ -108,6 +106,12 @@ data/
         └── dense/00.mp4 ... <N-1>.mp4       # generated target views
 ```
 
+### Inference Efficiency
+
+For faster inference on supported GPUs, optionally install [FlashAttention-3](https://github.com/Dao-AILab/flash-attention/tree/main/hopper) or [SageAttention](https://github.com/thu-ml/SageAttention). Our implementation automatically detects installed backends at runtime.
+
+See [Inference performance](docs/inference_performance.md) for measured 6-view runtimes and peak GPU memory usage on H20-3E, H200, RTX 5880 Ada, and RTX A6000 GPUs.
+
 ### Custom data
 
 Use an input video that:
@@ -117,10 +121,6 @@ Use an input video that:
 - shows one person in a full-body or upper-body shot.
 - has at least 121 frames.
 - contains only mild camera motion.
-
-### Inference Efficiency
-
-See [Inference performance](docs/inference_performance.md) for measured 6-view runtimes and peak GPU memory usage on H20-3E, H200, and RTX A6000 GPUs.
 
 ## 3DGS Reconstruction
 

--- a/docs/inference_performance.md
+++ b/docs/inference_performance.md
@@ -11,20 +11,35 @@ python inference.py \
 
 Each configuration reports the median of three runs.
 
-| GPU | Backend | GVHMR (min) | Skeleton extraction (min) | Denoising (min) | Peak CUDA allocated (GiB) | GPU memory (GiB) |
-| --- | --- | ---: | ---: | ---: | ---: | ---: |
-| H200 | SDPA | 0.94 | 0.57 | 9.17 | 43.34 | 140.40 |
-| H200 | FlashAttention-3 | 0.94 | 0.57 | 7.84 | 43.34 | 140.40 |
-| H20-3E | SDPA | 0.97 | 0.55 | 20.59 | 43.34 | 140.40 |
-| H20-3E | FlashAttention-3 | 0.97 | 0.55 | 16.62 | 43.34 | 140.40 |
-| RTX A6000 | SDPA | 1.70 | 1.06 | 22.93 | 43.32 | 47.99 |
+## Denoising
 
-Metrics are defined as follows:
+This table compares denoising time across attention backends.
+
+- `SDPA`, `FlashAttention-3`, and `SageAttention`: denoising time using each attention backend.
+- `Peak CUDA allocated`: maximum live tensor allocation during generation. It was identical across the tested backends on each GPU.
+- `GPU memory`: total device memory capacity.
+- `—`: backend unavailable on that GPU.
+
+| GPU | SDPA (min) | FlashAttention-3 (min) | SageAttention (min) | Peak CUDA allocated (GiB) | GPU memory (GiB) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| H200 | 9.17 | 7.84 | 7.86 | 43.34 | 140.40 |
+| H20-3E | 20.59 | 16.62 | 13.91 | 43.34 | 140.40 |
+| RTX 5880 Ada | 20.85 | — | 18.01 | 43.32 | 47.99 |
+| RTX A6000 | 22.93 | — | 22.75 | 43.32 | 47.99 |
+
+> [!NOTE]
+> SageAttention results use the official `sageattn` entry point, which automatically dispatches an architecture-specific kernel for each GPU.
+
+## Preprocessing
+
+This table reports preprocessing time before generation.
 
 - `GVHMR`: tracking, ViTPose, image-feature extraction, and motion prediction.
 - `Skeleton extraction`: target-view skeleton-condition rendering.
-- `Denoising`: the generation stage affected by the attention backend.
-- `Peak CUDA allocated`: the maximum live tensor allocation during generation.
 
-> [!NOTE]
-> On supported GPUs, FlashAttention-3 is selected automatically once installed.
+| GPU | GVHMR (min) | Skeleton extraction (min) |
+| --- | ---: | ---: |
+| H200 | 0.94 | 0.57 |
+| H20-3E | 0.97 | 0.55 |
+| RTX 5880 Ada | 0.94 | 1.00 |
+| RTX A6000 | 1.70 | 1.06 |


### PR DESCRIPTION
## Summary

- add SageAttention timings across H200, H20-3E, RTX 5880 Ada, and RTX A6000
- separate denoising and preprocessing measurements
- document automatic backend detection and GPU memory capacity

## Validation

- private test suite: 255 passed, 1 skipped
- sanitized release diff contains only README.md and docs/inference_performance.md
- public CLI help passed