### PR TITLE
Optimize request-scoped DiT inference

### DIFF
--- a/fdanyone/model/denoise.py
+++ b/fdanyone/model/denoise.py
@@ -1,37 +1,120 @@
-"""Shared denoising math for RCP, single-GPU, and multi-GPU execution."""
+"""Request-scoped denoising for RCP, single-GPU, and distributed execution."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from torch import Tensor
 
     from fdanyone.model.loader import Denoiser
+    from fdanyone.vendor.diffsynth.models.wan_video_dit import DiTRequestContext
 
 
-def denoise_group(
-    denoiser: Denoiser,
-    latents: Tensor,
-    source: Tensor,
-    context: Tensor,
-    pose_features: Tensor,
-    null_pose_feature: Tensor,
-    step_index: int,
-) -> Tensor:
-    """Advance one camera group by one scheduler step."""
+CameraGroup = tuple[int, ...]
 
-    import torch
 
-    timestep = denoiser.scheduler.timesteps[step_index]
-    batched_timestep = timestep.unsqueeze(0).to(dtype=denoiser.dtype, device=latents.device)
-    batched_timestep = torch.cat([batched_timestep] * latents.shape[0], dim=0)
-    prediction = denoiser.model(
-        x=latents,
-        x_src=source,
-        timestep=batched_timestep,
-        pose_features=pose_features,
-        null_pose_feature=null_pose_feature,
-        context=context,
-    )
-    return denoiser.scheduler.step(prediction, timestep, latents)
+class DenoisingRequest:
+    """Own all DiT state reusable within one denoising stage."""
+
+    def __init__(
+        self,
+        denoiser: Denoiser,
+        *,
+        source: Tensor,
+        context: Tensor,
+        null_pose_feature: Tensor,
+        target_views: int,
+        stage: str,
+    ) -> None:
+        if not stage:
+            raise ValueError("A denoising request requires a stage name.")
+        self._denoiser = denoiser
+        self._stage = stage
+        self._model_context: DiTRequestContext | None = denoiser.model.prepare_request(
+            x_src=source,
+            context=context,
+            null_pose_feature=null_pose_feature,
+            target_views=target_views,
+        )
+        self._step_calls = 0
+        self._model_calls = 0
+
+    @property
+    def retained_bytes(self) -> int:
+        return self._require_context().retained_bytes
+
+    def _require_context(self) -> DiTRequestContext:
+        if self._model_context is None:
+            raise RuntimeError("The denoising request is closed.")
+        return self._model_context
+
+    def step(
+        self,
+        latents: Tensor,
+        pose_features: Tensor,
+        step_index: int,
+        group: CameraGroup,
+    ) -> Tensor:
+        """Advance one ordered camera group by one scheduler step."""
+
+        if len(group) != latents.shape[0]:
+            raise ValueError(f"Camera group has {len(group)} views, but the latent batch has {latents.shape[0]}.")
+        timestep = self._denoiser.scheduler.timesteps[step_index]
+        batched_timestep = (
+            timestep.reshape(1)
+            .to(dtype=self._denoiser.dtype, device=latents.device)
+            .expand(latents.shape[0])
+            .contiguous()
+        )
+
+        prediction = self._denoiser.model(
+            x=latents,
+            timestep=batched_timestep,
+            pose_features=pose_features,
+            request=self._require_context(),
+        )
+        self._model_calls += 1
+        updated = self._denoiser.scheduler.step(prediction, timestep, latents)
+        self._step_calls += 1
+        return updated
+
+    def report(self) -> dict[str, object]:
+        context = self._require_context()
+        return {
+            "stage": self._stage,
+            "policy": "exact-eager",
+            "exact": {
+                "request_context": True,
+                "request_preparations": 1,
+                "step_calls": self._step_calls,
+                "model_calls": self._model_calls,
+                "cross_kv_blocks": len(context.cross_attention),
+                "cross_kv_projections": len(context.cross_attention),
+                "cross_kv_uses": self._model_calls * len(context.cross_attention),
+                "cross_kv_reuses": max(self._model_calls - 1, 0) * len(context.cross_attention),
+                "target_views": context.target_views,
+                "packed_views": context.packed_views,
+                "grid_size": list(context.grid_size),
+                "retained_bytes": context.retained_bytes,
+            },
+        }
+
+    def close(self) -> None:
+        """Release request-owned device tensors before the model can move."""
+
+        self._model_context = None
+
+    def __enter__(self) -> DenoisingRequest:
+        self._require_context()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/fdanyone/model/distributed.py
+++ b/fdanyone/model/distributed.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from torch import Tensor
 
     from fdanyone.model.conditioning import PoseFeatureBank
+    from fdanyone.model.denoise import DenoisingRequest
     from fdanyone.model.loader import Denoiser
 
 LOGGER = logging.getLogger("fdanyone")
@@ -46,6 +47,7 @@ class WorkerReport(TypedDict):
     denoise_seconds: float
     peak_vram_allocated_bytes: int
     peak_vram_reserved_bytes: int
+    denoiser_runtime: dict[str, object]
 
 
 @dataclass(frozen=True)
@@ -153,11 +155,9 @@ class _WorkerState:
     rank: int
     request: DistributedDenoiseRequest
     denoiser: Denoiser
+    runtime: DenoisingRequest
     device: str
     device_index: int
-    source: Tensor
-    context: Tensor
-    null_pose_feature: Tensor
     pose_features: Tensor
     latents: Tensor | None
     pose_feature_batch: Tensor
@@ -197,21 +197,11 @@ class _WorkerState:
         if self.rank >= len(wave):
             return torch.zeros_like(local_input)
 
-        from fdanyone.model.denoise import denoise_group
-
         group = wave[self.rank]
         for output_index, camera_id in enumerate(group):
             self.pose_feature_batch[output_index].copy_(self.pose_features[camera_id])
         with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
-            return denoise_group(
-                self.denoiser,
-                local_input,
-                self.source,
-                self.context,
-                self.pose_feature_batch,
-                self.null_pose_feature,
-                step_index,
-            )
+            return self.runtime.step(local_input, self.pose_feature_batch, step_index, group)
 
     def _gather_and_commit(self, local_result: Tensor, wave: StepGroups) -> None:
         import torch
@@ -246,6 +236,8 @@ class _WorkerState:
 def _load_worker_state(rank: int, request: DistributedDenoiseRequest, denoiser: Denoiser) -> _WorkerState:
     import torch
 
+    from fdanyone.model.denoise import DenoisingRequest
+
     device = request.devices[rank]
     payload = torch.load(
         Path(request.work_dir) / "inputs.pt",
@@ -265,15 +257,25 @@ def _load_worker_state(rank: int, request: DistributedDenoiseRequest, denoiser: 
         denoising_strength=request.denoising_strength,
         shift=request.scheduler_shift,
     )
+    source = payload["source"].to(dtype=denoiser.dtype, device=device)
+    context = payload["context"].to(dtype=denoiser.dtype, device=device)
+    null_pose_feature = payload["null_pose_feature"].to(dtype=denoiser.dtype, device=device)
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        runtime = DenoisingRequest(
+            denoiser,
+            source=source,
+            context=context,
+            null_pose_feature=null_pose_feature,
+            target_views=group_size,
+            stage="target",
+        )
     return _WorkerState(
         rank=rank,
         request=request,
         denoiser=denoiser,
+        runtime=runtime,
         device=device,
         device_index=int(device.removeprefix("cuda:")),
-        source=payload["source"].to(dtype=denoiser.dtype, device=device),
-        context=payload["context"].to(dtype=denoiser.dtype, device=device),
-        null_pose_feature=payload["null_pose_feature"].to(dtype=denoiser.dtype, device=device),
         pose_features=pose_features,
         latents=payload["initial_latents"].to(dtype=denoiser.dtype, device=device) if rank == 0 else None,
         pose_feature_batch=torch.empty(
@@ -333,6 +335,7 @@ def _worker(rank: int, request: DistributedDenoiseRequest) -> None:
         world_size=len(request.devices),
         timeout=timedelta(minutes=30),
     )
+    state = None
     try:
         state = _load_worker_state(rank, request, denoiser)
         dist.barrier(device_ids=[device_index])
@@ -350,10 +353,13 @@ def _worker(rank: int, request: DistributedDenoiseRequest) -> None:
             "denoise_seconds": denoise_seconds,
             "peak_vram_allocated_bytes": int(torch.cuda.max_memory_allocated(device_index)),
             "peak_vram_reserved_bytes": int(torch.cuda.max_memory_reserved(device_index)),
+            "denoiser_runtime": state.runtime.report(),
         }
         _publish_worker_result(state, report)
         dist.barrier(device_ids=[device_index])
     finally:
+        if state is not None:
+            state.runtime.close()
         if dist.is_initialized():
             dist.destroy_process_group()
 

--- a/fdanyone/model/inference.py
+++ b/fdanyone/model/inference.py
@@ -21,7 +21,7 @@ from fdanyone.assets import BaseAssets
 from fdanyone.config import INFERENCE
 from fdanyone.errors import FourDAnyoneError
 from fdanyone.model.conditioning import PoseFeatureBank, PoseFeatureCache, build_pose_feature_cache, load_prompt_context
-from fdanyone.model.denoise import denoise_group
+from fdanyone.model.denoise import DenoisingRequest
 from fdanyone.model.distributed import Routes, WorkerReport, denoise_targets_distributed, select_worker_devices
 from fdanyone.model.loader import Denoiser, load_denoiser
 from fdanyone.model.metrics import GenerationMetrics
@@ -62,6 +62,7 @@ class GeneratedViews:
     peak_vram_allocated_bytes: int
     peak_vram_reserved_bytes: int
     parallelism: ParallelismReport | None = None
+    denoiser_runtime: dict[str, object] | None = None
 
 
 @dataclass(frozen=True)
@@ -149,7 +150,7 @@ def _denoise_rcp(
     pose_features: PoseFeatureBank,
     device: str,
     seed: int,
-) -> Tensor:
+) -> tuple[Tensor, dict[str, object]]:
     import torch
     from tqdm.auto import tqdm
 
@@ -167,18 +168,22 @@ def _denoise_rcp(
     pose_features.copy_group(tuple(range(len(camera_ids))), pose_feature_batch)
     null_pose_feature = pose_features.null_on(device)
 
-    with torch.inference_mode(), _bf16_autocast():
+    with (
+        torch.inference_mode(),
+        _bf16_autocast(),
+        DenoisingRequest(
+            denoiser,
+            source=source,
+            context=context,
+            null_pose_feature=null_pose_feature,
+            target_views=len(camera_ids),
+            stage="rcp",
+        ) as request,
+    ):
         for step_index, _ in enumerate(tqdm(denoiser.scheduler.timesteps, desc=f"RCP 1-to-{len(camera_ids)}")):
-            latents = denoise_group(
-                denoiser,
-                latents,
-                source,
-                context,
-                pose_feature_batch,
-                null_pose_feature,
-                step_index,
-            )
-    return latents.detach().to("cpu")
+            latents = request.step(latents, pose_feature_batch, step_index, camera_ids)
+        runtime_report = request.report()
+    return latents.detach().to("cpu"), runtime_report
 
 
 def _denoise_targets_single(
@@ -189,7 +194,7 @@ def _denoise_targets_single(
     initial_latents: Tensor,
     routes: Routes,
     device: str,
-) -> Tensor:
+) -> tuple[Tensor, dict[str, object]]:
     import torch
     from tqdm.auto import tqdm
 
@@ -210,24 +215,28 @@ def _denoise_targets_single(
     group_size = len(routes[0][0])
     pose_feature_batch = pose_features.allocate_group(group_size, device)
 
-    with torch.inference_mode(), _bf16_autocast():
+    with (
+        torch.inference_mode(),
+        _bf16_autocast(),
+        DenoisingRequest(
+            denoiser,
+            source=source,
+            context=context,
+            null_pose_feature=null_pose_feature,
+            target_views=group_size,
+            stage="target",
+        ) as request,
+    ):
         for step_index, groups in enumerate(tqdm(routes, desc=f"Generate {num_views} target views")):
             for view_indices in groups:
                 index = torch.tensor(view_indices, dtype=torch.long, device=device)
                 local_latents = torch.index_select(latents, 0, index)
                 pose_features.copy_group(view_indices, pose_feature_batch)
-                local_latents = denoise_group(
-                    denoiser,
-                    local_latents,
-                    source,
-                    context,
-                    pose_feature_batch,
-                    null_pose_feature,
-                    step_index,
-                )
+                local_latents = request.step(local_latents, pose_feature_batch, step_index, view_indices)
                 latents.index_copy_(0, index, local_latents)
                 del local_latents
-    return latents.detach().to("cpu")
+        runtime_report = request.report()
+    return latents.detach().to("cpu"), runtime_report
 
 
 def _resolve_generation_plan(
@@ -283,14 +292,14 @@ def _generate_rcp_and_references(
     clip: CanonicalClip,
     seed: int,
     metrics: GenerationMetrics,
-) -> tuple[Tensor, tuple[Path, ...]]:
+) -> tuple[Tensor, tuple[Path, ...], dict[str, object]]:
     import torch
 
     rcp_pose_features = pose_cache.rcp
     if rcp_pose_features is None:
         raise FourDAnyoneError("RCP was enabled without precomputed proposal pose features.")
     with metrics.stage("rcp_denoise"), _model_on_device(denoiser.model, plan.primary_device):
-        rcp_latents = _denoise_rcp(
+        rcp_latents, runtime_report = _denoise_rcp(
             denoiser,
             vae,
             source_latents,
@@ -321,7 +330,7 @@ def _generate_rcp_and_references(
         reference_latents = vae.encode(reference_videos)
         target_sources = torch.cat([source_latents, reference_latents], dim=0)
     _merge_view_stage_peak(metrics, "reference_encode", vae)
-    return target_sources, published.videos
+    return target_sources, published.videos, runtime_report
 
 
 def _merge_view_stage_peak(metrics: GenerationMetrics, stage: str, vae: VaeExecutor) -> None:
@@ -419,11 +428,12 @@ def generate_views(
         _merge_view_stage_peak(metrics, "source_encode", vae)
 
         rcp_videos: tuple[Path, ...] = ()
+        rcp_runtime: dict[str, object] | None = None
         target_sources = source_latents
         if plan.view_plan.enable_rcp:
             if denoiser is None:
                 raise RuntimeError("RCP requires a primary-process denoiser.")
-            target_sources, rcp_videos = _generate_rcp_and_references(
+            target_sources, rcp_videos, rcp_runtime = _generate_rcp_and_references(
                 denoiser=denoiser,
                 vae=vae,
                 source_latents=source_latents,
@@ -443,6 +453,7 @@ def generate_views(
         del pose_cache
 
         parallelism = None
+        target_runtime: dict[str, object] | list[dict[str, object]] | None = None
         with metrics.stage("target_denoise"):
             routes = _target_routes(plan.view_plan)
             initial_latents = _noise(
@@ -468,11 +479,12 @@ def generate_views(
                     candidate_devices=plan.candidate_devices,
                     num_groups=plan.view_plan.num_groups,
                 )
+                target_runtime = [worker["denoiser_runtime"] for worker in parallelism["workers"]]
             else:
                 if denoiser is None:
                     raise RuntimeError("Single-GPU target generation requires a primary-process denoiser.")
                 with _model_on_device(denoiser.model, plan.primary_device):
-                    target_latents = _denoise_targets_single(
+                    target_latents, target_runtime = _denoise_targets_single(
                         denoiser,
                         target_sources,
                         context,
@@ -510,6 +522,11 @@ def generate_views(
             peak_vram_allocated_bytes=metrics.peak_vram_allocated_bytes,
             peak_vram_reserved_bytes=metrics.peak_vram_reserved_bytes,
             parallelism=parallelism,
+            denoiser_runtime={
+                "policy": "exact-eager",
+                "rcp": rcp_runtime,
+                "target": target_runtime,
+            },
         )
     finally:
         vae.close()

--- a/fdanyone/output.py
+++ b/fdanyone/output.py
@@ -171,6 +171,7 @@ def export_result(
         "total_elapsed_seconds": total_elapsed,
         "peak_vram_allocated_bytes": generated.peak_vram_allocated_bytes,
         "peak_vram_reserved_bytes": generated.peak_vram_reserved_bytes,
+        "denoiser_runtime": generated.denoiser_runtime,
     }
     if generated.parallelism is not None:
         generation_metadata["parallelism"] = generated.parallelism

--- a/fdanyone/vendor/diffsynth/models/wan_video_dit.py
+++ b/fdanyone/vendor/diffsynth/models/wan_video_dit.py
@@ -10,6 +10,7 @@ runtime.
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 
 import torch
 import torch.nn as nn
@@ -151,6 +152,23 @@ def rope_apply(x: torch.Tensor, freqs: torch.Tensor, num_heads: int) -> torch.Te
     return output.flatten(2)
 
 
+def rope_apply_inplace(x: torch.Tensor, freqs: torch.Tensor, num_heads: int) -> torch.Tensor:
+    """Apply RoPE in the projection buffer during inference."""
+
+    if torch.is_grad_enabled():
+        return rope_apply(x, freqs, num_heads)
+    headed = rearrange(x, "b s (n d) -> b s n d", n=num_heads)
+    fp64_bytes = headed[0].numel() * torch.empty((), dtype=torch.float64).element_size()
+    batch_chunk = max(
+        1,
+        min(headed.shape[0], ROPE_TEMPORARY_BUDGET_BYTES // (2 * fp64_bytes)),
+    )
+    for start in range(0, headed.shape[0], batch_chunk):
+        chunk = headed[start : start + batch_chunk]
+        chunk.copy_(_rotate_rope_chunk(chunk, freqs))
+    return x
+
+
 class RMSNorm(nn.Module):
     def __init__(self, dim: int, eps: float = 1e-5) -> None:
         super().__init__()
@@ -163,6 +181,49 @@ class RMSNorm(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         dtype = x.dtype
         return self._normalize_float(x.float()).to(dtype) * self.weight
+
+    def forward_inplace(self, x: torch.Tensor) -> torch.Tensor:
+        if torch.is_grad_enabled():
+            return self.forward(x)
+        x.copy_(self.forward(x))
+        return x
+
+
+@dataclass(frozen=True)
+class CrossAttentionKV:
+    """Projected prompt keys and values shared by every denoising step."""
+
+    key: torch.Tensor
+    value: torch.Tensor
+
+    def for_views(self, views: int) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.key.expand(views, -1, -1), self.value.expand(views, -1, -1)
+
+
+@dataclass(frozen=True)
+class DiTRequestContext:
+    """Exact tensors that remain invariant during one denoising stage."""
+
+    target_views: int
+    packed_views: int
+    grid_size: tuple[int, int, int]
+    source_tokens: torch.Tensor
+    spatial_freqs: torch.Tensor
+    multiview_freqs: torch.Tensor
+    cross_attention: tuple[CrossAttentionKV, ...]
+
+    @property
+    def retained_bytes(self) -> int:
+        tensors = (
+            self.source_tokens,
+            self.spatial_freqs,
+            self.multiview_freqs,
+            *(tensor for pair in self.cross_attention for tensor in (pair.key, pair.value)),
+        )
+        # Report the bytes that the request really keeps alive, once per
+        # allocation, even if a future representation introduces views.
+        storages = {tensor.untyped_storage().data_ptr(): tensor.untyped_storage().nbytes() for tensor in tensors}
+        return sum(storages.values())
 
 
 class SelfAttention(nn.Module):
@@ -177,12 +238,14 @@ class SelfAttention(nn.Module):
         self.norm_k = RMSNorm(dim, eps=eps)
 
     def forward(self, x: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
-        q = self.norm_q(self.q(x))
-        k = self.norm_k(self.k(x))
+        q = self.norm_q.forward_inplace(self.q(x))
+        k = self.norm_k.forward_inplace(self.k(x))
         v = self.v(x)
-        q = rope_apply(q, freqs, self.num_heads)
-        k = rope_apply(k, freqs, self.num_heads)
-        return self.o(attention(q, k, v, self.num_heads))
+        q = rope_apply_inplace(q, freqs, self.num_heads)
+        k = rope_apply_inplace(k, freqs, self.num_heads)
+        attended = attention(q, k, v, self.num_heads)
+        del q, k, v
+        return self.o(attended)
 
 
 class CrossAttention(nn.Module):
@@ -196,11 +259,23 @@ class CrossAttention(nn.Module):
         self.norm_q = RMSNorm(dim, eps=eps)
         self.norm_k = RMSNorm(dim, eps=eps)
 
-    def forward(self, x: torch.Tensor, context: torch.Tensor) -> torch.Tensor:
-        q = self.norm_q(self.q(x))
-        k = self.norm_k(self.k(context))
-        v = self.v(context)
-        return self.o(attention(q, k, v, self.num_heads))
+    def project_context(self, context: torch.Tensor, views: int) -> CrossAttentionKV:
+        # Projection kernels can choose different BF16 accumulation paths for
+        # different leading dimensions. Match the original per-forward shape
+        # once so reuse remains bit-identical, rather than projecting one batch
+        # and expanding it afterward.
+        context = repeat(context, "1 l c -> v l c", v=views)
+        key = self.norm_k.forward_inplace(self.k(context))
+        value = self.v(context)
+        # Every repeated view is identical. Keep one compact owning batch after
+        # the numerically significant projection has run at its original shape.
+        return CrossAttentionKV(key[:1].clone(), value[:1].clone())
+
+    def forward(self, x: torch.Tensor, context_kv: CrossAttentionKV) -> torch.Tensor:
+        q = self.q(x)
+        q = self.norm_q.forward_inplace(q)
+        key, value = context_kv.for_views(x.shape[0])
+        return self.o(attention(q, key, value, self.num_heads))
 
 
 class DiTBlock(nn.Module):
@@ -259,7 +334,7 @@ class DiTBlock(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        context: torch.Tensor,
+        context_kv: CrossAttentionKV,
         time_modulation: torch.Tensor,
         spatial_freqs: torch.Tensor,
         multiview_freqs: torch.Tensor,
@@ -283,7 +358,7 @@ class DiTBlock(nn.Module):
             shape,
         )
 
-        x = x + self.cross_attn(self.norm3(x), repeat(context, "1 l c -> v l c", v=x.shape[0]))
+        x = x + self.cross_attn(self.norm3(x), context_kv)
 
         residual = self._feed_forward(modulate(self.norm2(x), shift_mlp, scale_mlp))
         return x + gate_mlp * residual
@@ -425,12 +500,10 @@ class FourDAnyoneDiT(nn.Module):
             .to(device)
         )
 
-    def _pack_sources(
+    def _prepare_source_tokens(
         self,
-        x: torch.Tensor,
         sources: torch.Tensor,
-        grid_size: tuple[int, int, int],
-    ) -> tuple[torch.Tensor, int]:
+    ) -> tuple[torch.Tensor, int, tuple[int, int, int]]:
         source_views = int(sources.shape[0])
         if source_views == 1:
             primary_source = sources
@@ -441,8 +514,8 @@ class FourDAnyoneDiT(nn.Module):
         else:
             raise ValueError(f"4DAnyone requires 1 or 5 source views, got {source_views}.")
 
-        primary_tokens, _ = self._patchify(primary_source)
-        x = torch.cat([x, primary_tokens], dim=0)
+        primary_tokens, grid_size = self._patchify(primary_source)
+        source_tokens = primary_tokens
         packed_views = 1
 
         if reference_sources is not None:
@@ -452,70 +525,104 @@ class FourDAnyoneDiT(nn.Module):
             packed = rearrange(packed, "(g1 g2) c f h w -> 1 c f (g1 h) (g2 w)", g1=2, g2=2)
             frames, height, width = grid_size
             packed = packed[:, :, :frames, :height, :width]
-            packed = rearrange(packed, "1 c f h w -> 1 (f h w) c").to(dtype=x.dtype)
-            x = torch.cat([x, packed], dim=0)
+            packed = rearrange(packed, "1 c f h w -> 1 (f h w) c").to(dtype=source_tokens.dtype)
+            source_tokens = torch.cat([source_tokens, packed], dim=0)
             packed_views += 1
-        return x, packed_views
+        return source_tokens, packed_views, grid_size
 
     @staticmethod
-    def _add_pose_features(
-        x: torch.Tensor,
+    def _add_target_pose_features(
+        target_tokens: torch.Tensor,
         pose_features: torch.Tensor,
-        null_pose_feature: torch.Tensor,
         target_views: int,
-        packed_views: int,
         grid_size: tuple[int, int, int],
     ) -> torch.Tensor:
         frames, height, width = grid_size
         expected_pose = (target_views, MODEL_DIM, frames, height, width)
-        expected_null = (packed_views, MODEL_DIM, frames, height, width)
         if tuple(pose_features.shape) != expected_pose:
             raise ValueError(f"Expected pose features {expected_pose}, got {tuple(pose_features.shape)}.")
+        pose_tokens = rearrange(pose_features, "v c f h w -> v (f h w) c")
+        if torch.is_grad_enabled():
+            return target_tokens + pose_tokens
+        target_tokens.add_(pose_tokens)
+        return target_tokens
+
+    def prepare_request(
+        self,
+        *,
+        x_src: torch.Tensor,
+        context: torch.Tensor,
+        null_pose_feature: torch.Tensor,
+        target_views: int,
+    ) -> DiTRequestContext:
+        """Project immutable source and prompt conditioning exactly once."""
+
+        if target_views <= 0:
+            raise ValueError(f"A denoising request requires target views, got {target_views}.")
+        if context.shape[0] != 1:
+            raise ValueError(f"4DAnyone requires one shared prompt context, got {context.shape[0]}.")
+
+        source_tokens, packed_views, grid_size = self._prepare_source_tokens(x_src)
+        frames, height, width = grid_size
+        expected_null = (packed_views, MODEL_DIM, frames, height, width)
         if tuple(null_pose_feature.shape) != expected_null:
             raise ValueError(f"Expected null pose features {expected_null}, got {tuple(null_pose_feature.shape)}.")
-        pose_tokens = rearrange(pose_features, "v c f h w -> v (f h w) c")
         null_tokens = rearrange(null_pose_feature, "v c f h w -> v (f h w) c")
-        if torch.is_grad_enabled():
-            return torch.cat([x[:target_views] + pose_tokens, x[target_views:] + null_tokens], dim=0)
-        x[:target_views].add_(pose_tokens)
-        x[target_views:].add_(null_tokens)
-        return x
+        source_tokens = source_tokens + null_tokens
+
+        embedded_context = self.text_embedding(context)
+        total_views = target_views + packed_views
+        cross_attention = tuple(
+            block.cross_attn.project_context(embedded_context, total_views) for block in self.blocks
+        )
+        return DiTRequestContext(
+            target_views=target_views,
+            packed_views=packed_views,
+            grid_size=grid_size,
+            source_tokens=source_tokens,
+            spatial_freqs=self._spatial_frequencies(frames, height, width, source_tokens.device),
+            multiview_freqs=self._multiview_frequencies(total_views, height, width, source_tokens.device),
+            cross_attention=cross_attention,
+        )
 
     def forward(
         self,
         *,
         x: torch.Tensor,
-        x_src: torch.Tensor,
         timestep: torch.Tensor,
-        context: torch.Tensor,
         pose_features: torch.Tensor,
-        null_pose_feature: torch.Tensor,
+        request: DiTRequestContext,
     ) -> torch.Tensor:
-        context = self.text_embedding(context)
         target_views = int(x.shape[0])
-        x, grid_size = self._patchify(x)
-        frames, height, width = grid_size
-        spatial_freqs = self._spatial_frequencies(frames, height, width, x.device)
-
-        x, packed_views = self._pack_sources(x, x_src, grid_size)
-        timestep = torch.cat([timestep, torch.zeros(packed_views, dtype=timestep.dtype, device=timestep.device)])
-        time_embedding = self.time_embedding(sinusoidal_embedding_1d(FREQUENCY_DIM, timestep).to(x.dtype))
+        if target_views != request.target_views:
+            raise ValueError(f"Request has {request.target_views} target views, got {target_views}.")
+        target_tokens, grid_size = self._patchify(x)
+        if grid_size != request.grid_size:
+            raise ValueError(f"Request grid {request.grid_size} does not match target grid {grid_size}.")
+        timestep = torch.cat(
+            [timestep, torch.zeros(request.packed_views, dtype=timestep.dtype, device=timestep.device)]
+        )
+        time_embedding = self.time_embedding(sinusoidal_embedding_1d(FREQUENCY_DIM, timestep).to(target_tokens.dtype))
         time_modulation = self.time_projection(time_embedding).unflatten(1, (6, MODEL_DIM))
-
-        x = self._add_pose_features(
-            x,
+        target_tokens = self._add_target_pose_features(
+            target_tokens,
             pose_features,
-            null_pose_feature,
             target_views,
-            packed_views,
             grid_size,
         )
-        total_views = target_views + packed_views
-        multiview_freqs = self._multiview_frequencies(total_views, height, width, x.device)
+        x = torch.cat([target_tokens, request.source_tokens], dim=0)
+        total_views = target_views + request.packed_views
+        frames, height, width = grid_size
         shape = (total_views, frames, height, width)
-        for block in self.blocks:
-            x = block(x, context, time_modulation, spatial_freqs, multiview_freqs, shape)
+        for block, context_kv in zip(self.blocks, request.cross_attention, strict=True):
+            x = block(
+                x,
+                context_kv,
+                time_modulation,
+                request.spatial_freqs,
+                request.multiview_freqs,
+                shape,
+            )
 
         x = x[:target_views]
-        time_embedding = time_embedding[:target_views]
-        return self._unpatchify(self.head(x, time_embedding), grid_size)
+        return self._unpatchify(self.head(x, time_embedding[:target_views]), grid_size)


### PR DESCRIPTION
## Summary

- scope reusable DiT inference state to one denoising request
- reuse request-local RoPE, normalization, source-view, and cross-attention data
- preserve single- and multi-GPU request lifecycles and output metadata

This is the sanitized public snapshot of private source commit `a0bd1af309f77ac88046192564eb1f9f8700bcab`. It intentionally excludes the later Wan2.2 Turbo LoRA integration and GVHMR tracking fallback.

## Validation

- private Python 3.10/3.11/3.12 CI passed
- private source-release rehearsal passed
- staged public diff contains exactly five production files
- Ruff check and format check passed
- public Pages workflow and pinned GVHMR gitlink are unchanged