### PR TITLE
Release: reduce inference FFN peak memory

### DIFF
--- a/fdanyone/vendor/diffsynth/models/wan_video_dit.py
+++ b/fdanyone/vendor/diffsynth/models/wan_video_dit.py
@@ -300,6 +300,11 @@ class DiTBlock(nn.Module):
 
     def _feed_forward(self, x: torch.Tensor) -> torch.Tensor:
         hidden = self.ffn[0](x)
+        # ``x`` is the owned BF16 modulation result, not the block residual.
+        # Release it after the first projection so the allocator can reuse its
+        # token slab for the equally shaped second-projection output.
+        if not torch.is_grad_enabled():
+            del x
         hidden = gelu_tanh(hidden)
         return self.ffn[2](hidden)
 


### PR DESCRIPTION
## Summary

- Release the inference-owned BF16 FFN modulation input after its first projection so CUDA can reuse that storage for the output projection.
- Preserve the trained full-shape GEMMs, operation order, block residual, and grad-enabled path.

## Validation

- RTX A6000 and H200: three same-GPU A/B pairs each were bitwise exact; the H20-3E reference was also exact.
- Target-denoise live allocation decreased by about 0.794 GiB (3.45%).
- RTX A6000 and isolated H200 timing showed no meaningful performance change.
- A physical RTX 4090 completed the default 24-view / group-6 pipeline that the previous release could not complete due to OOM.