### PR TITLE
Release: fix 24 GB and multi-GPU inference handling

### DIFF
--- a/fdanyone/device.py
+++ b/fdanyone/device.py
@@ -3,24 +3,102 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from collections.abc import MutableMapping, Sequence
 
 from fdanyone.errors import ConfigurationError
 
 CUDA_ALLOCATOR_CONF = "PYTORCH_CUDA_ALLOC_CONF"
 CUDA_MAX_SPLIT_SIZE_MB = 4096
+CUDA_EXPANDABLE_SEGMENT_MAX_MEMORY_BYTES = 24 * 1024**3
 
 
-def configure_inference_cuda_allocator(environment: MutableMapping[str, str] | None = None) -> None:
-    """Keep the DiT's reusable FFN allocation from being split into small blocks."""
+def _visible_gpu_identifiers(environment: MutableMapping[str, str]) -> tuple[str, ...] | None:
+    """Return CUDA-visible NVIDIA identifiers without initializing CUDA."""
+
+    raw = environment.get("CUDA_VISIBLE_DEVICES")
+    if raw is None:
+        raw = environment.get("NVIDIA_VISIBLE_DEVICES")
+    if raw is None or raw.strip().lower() == "all":
+        return None
+    if raw.strip().lower() in {"", "-1", "none", "void"}:
+        return ()
+    return tuple(identifier.strip() for identifier in raw.split(",") if identifier.strip())
+
+
+def _selected_gpu_identifiers(
+    gpu_ids: Sequence[int] | None,
+    environment: MutableMapping[str, str],
+) -> tuple[str, ...] | None:
+    """Map CUDA-visible indices to identifiers accepted by ``nvidia-smi``."""
+
+    visible = _visible_gpu_identifiers(environment)
+    if gpu_ids is None:
+        return visible
+    if (
+        isinstance(gpu_ids, (str, bytes))
+        or not isinstance(gpu_ids, Sequence)
+        or not gpu_ids
+        or any(isinstance(gpu_id, bool) or not isinstance(gpu_id, int) or gpu_id < 0 for gpu_id in gpu_ids)
+    ):
+        return ()
+    if visible is None:
+        return tuple(str(gpu_id) for gpu_id in gpu_ids)
+    if any(gpu_id >= len(visible) for gpu_id in gpu_ids):
+        return ()
+    return tuple(visible[gpu_id] for gpu_id in gpu_ids)
+
+
+def _query_total_memory_bytes(identifiers: tuple[str, ...] | None) -> tuple[int, ...]:
+    """Query selected GPU capacities through the driver utility, before PyTorch."""
+
+    if identifiers == ():
+        return ()
+    command = ["nvidia-smi"]
+    if identifiers is not None:
+        command.append(f"--id={','.join(identifiers)}")
+    command.extend(("--query-gpu=memory.total", "--format=csv,noheader,nounits"))
+    try:
+        completed = subprocess.run(command, check=True, capture_output=True, text=True, timeout=5)
+        totals_mib = tuple(int(line.strip()) for line in completed.stdout.splitlines() if line.strip())
+    except (FileNotFoundError, subprocess.SubprocessError, ValueError):
+        return ()
+    return tuple(total_mib * 1024**2 for total_mib in totals_mib)
+
+
+def selected_gpus_need_expandable_segments(
+    gpu_ids: Sequence[int] | None,
+    environment: MutableMapping[str, str] | None = None,
+) -> bool:
+    """Return whether any selected GPU has at most 24 GiB of device memory."""
+
+    environment = os.environ if environment is None else environment
+    identifiers = _selected_gpu_identifiers(gpu_ids, environment)
+    totals = _query_total_memory_bytes(identifiers)
+    return bool(totals) and any(total <= CUDA_EXPANDABLE_SEGMENT_MAX_MEMORY_BYTES for total in totals)
+
+
+def configure_inference_cuda_allocator(
+    environment: MutableMapping[str, str] | None = None,
+    *,
+    use_expandable_segments: bool = False,
+) -> None:
+    """Configure the long-lived DiT allocator before the first PyTorch import."""
 
     environment = os.environ if environment is None else environment
     current = environment.get(CUDA_ALLOCATOR_CONF, "").strip()
     options = tuple(option.strip() for option in current.split(",") if option.strip())
-    if any(option.partition(":")[0] == "max_split_size_mb" for option in options):
+    keys = {option.partition(":")[0] for option in options}
+    backend = next((option.partition(":")[2] for option in options if option.partition(":")[0] == "backend"), None)
+    if backend not in {None, "native"}:
         return
-    required = f"max_split_size_mb:{CUDA_MAX_SPLIT_SIZE_MB}"
-    environment[CUDA_ALLOCATOR_CONF] = f"{current},{required}" if current else required
+    additions: list[str] = []
+    if use_expandable_segments and "expandable_segments" not in keys:
+        additions.append("expandable_segments:True")
+    if "max_split_size_mb" not in keys:
+        additions.append(f"max_split_size_mb:{CUDA_MAX_SPLIT_SIZE_MB}")
+    if additions:
+        environment[CUDA_ALLOCATOR_CONF] = ",".join((*options, *additions))
 
 
 def select_cuda_device(device: str) -> tuple[str, int]:

--- a/fdanyone/model/vae.py
+++ b/fdanyone/model/vae.py
@@ -167,7 +167,6 @@ class VaeExecutor:
                 raise
             finally:
                 model.to("cpu")
-                torch.cuda.empty_cache()
 
         with ThreadPoolExecutor(max_workers=worker_count, thread_name_prefix="vae") as pool:
             futures = [pool.submit(run, worker_index) for worker_index in range(worker_count)]
@@ -179,6 +178,12 @@ class VaeExecutor:
                 for future in futures:
                     future.cancel()
                 raise
+        # Do not let a completed worker release cached mappings while a peer is
+        # still executing.  This raced with expandable segments in low-memory
+        # multi-GPU inference.  Join every worker before serial cache cleanup.
+        for worker_index in range(worker_count):
+            torch.cuda.set_device(int(self.devices[worker_index].removeprefix("cuda:")))
+            torch.cuda.empty_cache()
         self.last_peak_vram_bytes = peaks
 
     @staticmethod

--- a/inference.py
+++ b/inference.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 
-from fdanyone.device import configure_inference_cuda_allocator
+from fdanyone.device import configure_inference_cuda_allocator, selected_gpus_need_expandable_segments
 from fdanyone.errors import FourDAnyoneError
 
 
@@ -63,7 +63,9 @@ def inference(
 
     # This must run before the first model/PyTorch import. It protects the
     # reusable 5--6 GiB DiT FFN allocation from allocator fragmentation.
-    configure_inference_cuda_allocator()
+    configure_inference_cuda_allocator(
+        use_expandable_segments=selected_gpus_need_expandable_segments(gpu_ids),
+    )
     # Keep model imports out of module scope so ``--help`` stays lightweight.
     from fdanyone.pipeline import run_pipeline
 


### PR DESCRIPTION
## Summary

- Enable expandable CUDA segments automatically when any selected GPU has at most 24 GiB of memory.
- Preserve explicit allocator settings and non-native allocator backends.
- Move VAE cache cleanup after all parallel GPU workers complete to avoid a low-memory multi-GPU race.

## Validation

- Ruff lint and formatting checks passed.
- CPU test suite: 355 passed, 5 skipped because PyTorch is unavailable in the release-check environment.
- Public CLI help, sanitized snapshot, submodule pin, and privacy checks passed.

The refreshed performance documentation will be published in a separate follow-up PR.